### PR TITLE
Fix URL of packaged builds in the README

### DIFF
--- a/README
+++ b/README
@@ -127,5 +127,5 @@ Binaries:
 
 Binaries for a number of Linux distributions are built
 in the Opensuse build service. You can find them at
-https://build.opensuse.org/package/repositories?package=rootsh&project=home%3Ajpschewe
+https://build.opensuse.org/package/show/home:jpschewe/rootsh
 


### PR DESCRIPTION
The CI link is still wrong, but I'm not sure what the right value should be.
