### PR TITLE
Don't log output of commands that use a binary protocol.

### DIFF
--- a/src/rootsh.c
+++ b/src/rootsh.c
@@ -424,6 +424,24 @@ int main(int argc, char **argv) {
   */
   ioctl(STDIN_FILENO, TIOCGWINSZ, (char *)&winSize);
   
+  /*
+  // Don't log output of commands that use a binary protocol.
+  */
+  {
+    const char *scpPrefix = "scp ";
+    const char *sftpPrefix = "/usr/libexec/openssh/sftp-server ";
+    const char *rsyncPrefix = "rsync ";
+    if (shellCommands && (
+         strncmp(shellCommands, scpPrefix, strlen(scpPrefix)) == 0
+      || strncmp(shellCommands, sftpPrefix, strlen(sftpPrefix)) == 0
+      || strncmp(shellCommands, rsyncPrefix, strlen(rsyncPrefix)) == 0
+    )) {
+      endlogging();
+      execShell(shell, shellCommands); 
+      exit(EXIT_SUCCESS);
+    }
+  }
+
   /* 
   //  fork a child process, create a pty pair, 
   //  make the slave the controlling terminal,


### PR DESCRIPTION
When I set rootsh as my login shell in `/etc/passwd`, then run `scp` or `sftp` or `rsync` to transfer some binary files, each of those commands' raw binary protocol data gets logged, which isn't very useful.  This pull request turns off logging for those commands.

Before:

    May 26 12:09:25 localhost rootsh[22551]: root: root=root,: logging new login session (rootsh[22551])
    May 26 12:09:25 localhost rootsh[22551]: root: 000: shell commands: rsync --server --sender -logDtpre.iLsfxC . /var/log #012#036
    May 26 12:09:25 localhost rootsh[22551]: root: 001: ]?Y?#011???
    May 26 12:09:25 localhost rootsh[22551]: root: 002: cron-20180401#005?2Z???:#004#020maillog-20180201
    …

After:

    May 26 12:55:05 localhost rootsh[26404]: root: root=root,: logging new login session (rootsh[26404])
    May 26 12:55:05 localhost rootsh[26404]: root: 000: shell commands: rsync --server --sender -logDtpre.iLsfxC . /var/log
    May 26 12:55:05 localhost rootsh[26404]: root: root,: closing rootsh session (rootsh[26404])
